### PR TITLE
Fix Grok JSON parsing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,9 @@
-from .ponyxl import PonyXL
-from .flux import Flux
+if __package__:
+    from .ponyxl import PonyXL
+    from .flux import Flux
+else:
+    from ponyxl import PonyXL
+    from flux import Flux
 
 NODE_CLASS_MAPPINGS = {
     "PonyXL": PonyXL,

--- a/flux.py
+++ b/flux.py
@@ -1,9 +1,16 @@
 import requests
 import json
+import re
 
 class Flux:
     def __init__(self):
         pass
+
+    @staticmethod
+    def _extract_json(text: str) -> str:
+        """Return the first JSON object found in the text."""
+        match = re.search(r"{.*}", text, re.DOTALL)
+        return match.group(0) if match else "{}"
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -44,7 +51,11 @@ class Flux:
             response = requests.post("https://api.x.ai/v1/chat/completions", json=data, headers=headers)
             response.raise_for_status()
             result = response.json().get("choices", [{}])[0].get("message", {}).get("content", "{}")
-            result_dict = json.loads(result)
+            clean_json = self._extract_json(result)
+            try:
+                result_dict = json.loads(clean_json)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON returned: {clean_json}") from e
             flux_prompt = result_dict.get("flux_prompt", prompt)
             wan_prompt = result_dict.get("wan_prompt", "")
             negative_prompt = result_dict.get("negative_prompt", "blurry, low_detail, bad_anatomy")

--- a/ponyxl.py
+++ b/ponyxl.py
@@ -1,9 +1,16 @@
 import requests
 import json
+import re
 
 class PonyXL:
     def __init__(self):
         pass
+
+    @staticmethod
+    def _extract_json(text: str) -> str:
+        """Return the first JSON object found in the text."""
+        match = re.search(r"{.*}", text, re.DOTALL)
+        return match.group(0) if match else "{}"
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -44,7 +51,11 @@ class PonyXL:
             response = requests.post("https://api.x.ai/v1/chat/completions", json=data, headers=headers)
             response.raise_for_status()
             result = response.json().get("choices", [{}])[0].get("message", {}).get("content", "{}")
-            result_dict = json.loads(result)
+            clean_json = self._extract_json(result)
+            try:
+                result_dict = json.loads(clean_json)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON returned: {clean_json}") from e
             ponyxl_prompt = result_dict.get("ponyxl_prompt", prompt)
             wan_prompt = result_dict.get("wan_prompt", "")
             negative_prompt = result_dict.get("negative_prompt", "blurry, low_quality, bad_anatomy, oversaturated")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,46 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+import importlib.util
+
+repo_root = Path(__file__).resolve().parents[1]
+
+def load_module(name, filename):
+    spec = importlib.util.spec_from_file_location(name, repo_root / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+ponyxl = load_module("ponyxl", "ponyxl.py")
+flux = load_module("flux", "flux.py")
+PonyXL = ponyxl.PonyXL
+Flux = flux.Flux
+
+class TestPromptNodes(unittest.TestCase):
+    def _mock_response(self, content):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": content}}]
+        }
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    @patch("requests.post")
+    def test_ponyxl_extracts_json_from_codeblock(self, mock_post):
+        content = "```json\n{\"ponyxl_prompt\": \"tag1\"}\n```"
+        mock_post.return_value = self._mock_response(content)
+        node = PonyXL()
+        result = node.generate_prompts("test", "key", "motion")
+        self.assertIn("tag1", result["result"][0])
+
+    @patch("requests.post")
+    def test_flux_extracts_json_from_codeblock(self, mock_post):
+        content = "```json\n{\n    \"flux_prompt\": \"tag2\"\n}\n```"
+        mock_post.return_value = self._mock_response(content)
+        node = Flux()
+        result = node.generate_prompts("test", "key", "motion")
+        self.assertIn("tag2", result["result"][0])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve robustness of ponyxl and flux nodes when the Grok API returns JSON wrapped in code blocks
- allow `__init__.py` to be imported as a module or package
- add regression tests for the new JSON extraction logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842697c1db08322b93f77390c37d2eb