### PR TITLE
Fix Wan naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To use these nodes, you’ll need an API key from [x.ai](https://x.ai/api). Inpu
 
 - Perfect for NSFW image prompting using PonyXL
 - Abstract stylized generation with Flux
-- Natural-language video scene building for WAN
+- Natural-language video scene building for Wan
 - Ideal for artists, animators, and prompt engineers wanting more automation and precision
 
 ---


### PR DESCRIPTION
## Summary
- standardize the video model name "Wan" in README

## Testing
- `grep -n Wan -i README.md`

------
https://chatgpt.com/codex/tasks/task_e_68426a8449488322b10427facefc1cb6