### PR TITLE
Add tests for prompt generators

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,9 @@
-from .ponyxl import PonyXL
-from .flux import Flux
+try:
+    from .ponyxl import PonyXL
+    from .flux import Flux
+except ImportError:  # fallback for running without package context
+    from ponyxl import PonyXL
+    from flux import Flux
 
 NODE_CLASS_MAPPINGS = {
     "PonyXL": PonyXL,

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -1,0 +1,46 @@
+import json
+from unittest.mock import Mock, patch
+
+from flux import Flux
+
+
+def _make_response(data):
+    mock_resp = Mock()
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.return_value = data
+    return mock_resp
+
+
+def test_generate_prompts_success():
+    result_payload = {
+        "flux_prompt": "flux",
+        "wan_prompt": "wan",
+        "negative_prompt": "neg",
+        "explanation": "ok",
+    }
+    api_response = {"choices": [{"message": {"content": json.dumps(result_payload)}}]}
+    with patch("flux.requests.post", return_value=_make_response(api_response)):
+        out = Flux().generate_prompts("a dog", "key", "run")
+    assert out["result"] == ("flux", "wan", "neg")
+    assert out["ui"]["text"] == ["ok"]
+
+
+def test_generate_prompts_missing_api_key():
+    out = Flux().generate_prompts("a dog", "", "run")
+    assert out["ui"]["text"] == ["No API key provided."]
+    assert out["result"] == (
+        "a dog",
+        "",
+        "blurry, low_detail, bad_anatomy",
+    )
+
+
+def test_generate_prompts_api_failure():
+    with patch("flux.requests.post", side_effect=Exception("fail")):
+        out = Flux().generate_prompts("a dog", "key", "run")
+    assert out["result"] == (
+        "a dog",
+        "",
+        "blurry, low_detail, bad_anatomy",
+    )
+    assert out["ui"]["text"][0].startswith("Error calling Grok API:")

--- a/tests/test_ponyxl.py
+++ b/tests/test_ponyxl.py
@@ -1,0 +1,46 @@
+import json
+from unittest.mock import Mock, patch
+
+from ponyxl import PonyXL
+
+
+def _make_response(data):
+    mock_resp = Mock()
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.return_value = data
+    return mock_resp
+
+
+def test_generate_prompts_success():
+    result_payload = {
+        "ponyxl_prompt": "pony",
+        "wan_prompt": "wan",
+        "negative_prompt": "neg",
+        "explanation": "ok",
+    }
+    api_response = {"choices": [{"message": {"content": json.dumps(result_payload)}}]}
+    with patch("ponyxl.requests.post", return_value=_make_response(api_response)):
+        out = PonyXL().generate_prompts("a cat", "key", "jump")
+    assert out["result"] == ("pony", "wan", "neg")
+    assert out["ui"]["text"] == ["ok"]
+
+
+def test_generate_prompts_missing_api_key():
+    out = PonyXL().generate_prompts("a cat", "", "jump")
+    assert out["ui"]["text"] == ["No API key provided."]
+    assert out["result"] == (
+        "a cat",
+        "",
+        "blurry, low_quality, bad_anatomy, oversaturated",
+    )
+
+
+def test_generate_prompts_api_failure():
+    with patch("ponyxl.requests.post", side_effect=Exception("fail")):
+        out = PonyXL().generate_prompts("a cat", "key", "jump")
+    assert out["result"] == (
+        "a cat",
+        "",
+        "blurry, low_quality, bad_anatomy, oversaturated",
+    )
+    assert out["ui"]["text"][0].startswith("Error calling Grok API:")


### PR DESCRIPTION
## Summary
- add regression tests for PonyXL and Flux prompt generation
- adjust `__init__.py` to work when imported outside a package

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_68426a86e3848322a64e525eb466faff